### PR TITLE
Remove jQuery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem 'rails', '~> 5.1.1'
 gem 'pg'
 
 gem 'turbolinks', '~> 5'
-gem 'jquery-rails'
 
 gem 'geocoder'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,10 +71,6 @@ GEM
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     i18n (0.8.4)
-    jquery-rails (4.3.1)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -200,7 +196,6 @@ DEPENDENCIES
   database_cleaner
   factory_girl_rails
   geocoder
-  jquery-rails
   listen (>= 3.0.5, < 3.2)
   pg
   pry

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,6 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require rails-ujs
 //= require turbolinks
-//= require jquery
-//= require jquery_ujs
 //= require_tree .

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -3,32 +3,33 @@
 
   <script type="text/javascript">
 
-    $("#new_point_creator").on(
-      "ajax:success", function (e, data, status, xhr) {
+    document.getElementById("new_point_creator").addEventListener(
+      "ajax:success", function (event) {
+        var data = event.detail[0];
         refreshJobStaus(data.job_status_id);
       });
 
     function refreshJobStaus(jobStatusId) {
-      $.ajax({
+      Rails.ajax({
           url: '/point_creator_job_statuses/' + jobStatusId,
+          type: 'GET',
           error: function (xhr, status, error) {
             console.log(status);
           },
-          statusCode: {
-            200: function (data, status, xhr) {
-                   setTimeout(refreshJobStaus, 1000, jobStatusId);
-                 },
-            201: function (data, status, xhr) {
-                var newFeature = new ol.Feature({
-                  geometry: new ol.geom.Point(
-                      ol.proj.fromLonLat([data.long, data.lat])),
-                  name: data.name,
-                  });
+          success: function (data, statusText, xhr) {
+            if (xhr.status == 200) {
+              setTimeout(refreshJobStaus, 1000, jobStatusId);
+            } else if (xhr.status == 201) {
+              var newFeature = new ol.Feature({
+                geometry: new ol.geom.Point(
+                    ol.proj.fromLonLat([data.long, data.lat])),
+                name: data.name,
+                });
 
-                newFeature.setStyle(iconStyle);
+              newFeature.setStyle(iconStyle);
 
-                map.getLayers().item(1).getSource().addFeature(newFeature);
-                 }
+              map.getLayers().item(1).getSource().addFeature(newFeature);
+            }
           }
         }
       );


### PR DESCRIPTION
Now that jQuery is optional and no longer the default for Rails, this
means we can drop this dependency and serve a little bit lighter load to
all our pages.

Make use of the `addEventListener` function on elements (the mirror of
`dispatchEvent`) to listen for the `ajax:success` event on our
`new_point_creator` form. The argument to the callback changed: the
second param (`data`) is now part of the first argument (`event`),
accessed as `event.detail[0]`.

Use the `Rails.ajax` function to get one of the niceties jQuery
provides: a wrapper around XHR inconsistencies. It is slightly different
from the jQuery implementation: it requires the HTTP verb (`type`), and
`success` is a function where we must manually dispatch over the HTTP
response code (`xhr.status`).

---

I tried this in the browser but not the tests. Apologies.